### PR TITLE
Remove not needed GITHUB_REF

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,13 +3,8 @@ const { GitHub, context } = require('@actions/github');
 async function run() {
 
   try {
-    const { GITHUB_REF, GITHUB_SHA, GITHUB_TOKEN } = process.env;
+    const { GITHUB_SHA, GITHUB_TOKEN } = process.env;
     const tagName = core.getInput('tag_name');
-    if (!GITHUB_REF) {
-      core.setFailed('Missing GITHUB_REF');
-      return;
-    }
-
     if (!GITHUB_SHA) {
       core.setFailed('Missing GITHUB_SHA');
       return;


### PR DESCRIPTION
Hi @richardsimko!

I am using your GitHub Action in the context of my [Nx](https://nx.dev/react) based monorepo. I am using this action to determine the diff between deployments. I am using GitHub deployments api and the corresponding GitHub Action integration.
Unfortunately in this case the env var `GITHUB_REF` is not set and this GitHub Action fails.

I checked the source and see that `GITHUB_REF` is not used at all but validated for.

I removed this check in a fork of this repo that I am currently using in my workflow and it works nicely.

Not sure if this check has/had a deeper meaning here but maybe you can remove it general?

Hence this PR ;)

Best,

Florian