### PR TITLE
Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "src/main.js"
 branding:
   icon: "tag"


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/